### PR TITLE
Add scripts for CI testing     

### DIFF
--- a/scripts/testing/build.sh
+++ b/scripts/testing/build.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+set -x
+set -o pipefail
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. "$CURRENT_DIR"/env.sh
+
+if [ $# -eq 1 ]
+ then
+    if [ $1 = "core" ]; then
+    	product="core"
+	elif [ $1 = "bringup" ]; then
+		product="bringup"
+	elif [ $1 = "terminal" ]; then
+		product="terminal"
+	elif [ $1 = "workstation" ]; then
+		product="workstation"
+	else 
+		>&2 echo "not a valid product name, must be core,"\
+		          "bringup, terminal or workstation."
+		exit 1
+	fi
+else 
+	>&2 echo "not a valid product name, must be core,"\
+		          "bringup, terminal or workstation."
+	exit 1
+fi
+
+cd $FUCHSIA_DIR
+$FX set "$product".x64 --args base_package_labels+=[\"//bundles/buildbot:"$product"\"]
+$FX build

--- a/scripts/testing/env.sh
+++ b/scripts/testing/env.sh
@@ -4,7 +4,10 @@ FUCHSIA_DIR="$CURRENT_DIR"/../..
 OUTPUT_DIR=$FUCHSIA_DIR/out/default
 ZIRCON_OUTPUT_DIR=$FUCHSIA_DIR/out/default.zircon
 
-$FUCHSIA_DIR/.jiri_root/bin/fx metrics disable
+
+if [ -f $FUCHSIA_DIR/.jiri_root/bin/fx ]; then
+	$FUCHSIA_DIR/.jiri_root/bin/fx metrics disable
+fi
 
 QEMU_TEST_CMDS=/tmp/runcmds
 

--- a/scripts/testing/env.sh
+++ b/scripts/testing/env.sh
@@ -1,0 +1,26 @@
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+FUCHSIA_DIR="$CURRENT_DIR"/../..
+
+OUTPUT_DIR=$FUCHSIA_DIR/out/default
+ZIRCON_OUTPUT_DIR=$FUCHSIA_DIR/out/default.zircon
+
+$FUCHSIA_DIR/.jiri_root/bin/fx metrics disable
+
+QEMU_TEST_CMDS=/tmp/runcmds
+
+ALL_TESTS=/tmp/tests.json
+QEMU_TESTS=/tmp/qemu-tests
+HOST_TESTS=/tmp/host-tests.json
+QEMU_HOST_RESULTS_DIR=`mktemp -d`
+
+JIRI=$FUCHSIA_DIR/.jiri_root/bin/jiri
+FX=$FUCHSIA_DIR/.jiri_root/bin/fx
+ZBI=$ZIRCON_OUTPUT_DIR/tools/zbi
+MINFS=$ZIRCON_OUTPUT_DIR/tools/minfs
+RUN_ZIRCON=$FUCHSIA_DIR/zircon/scripts/run-zircon-x64
+TESTSHARDER=$FUCHSIA_DIR/buildtools/linux-x64/testsharder
+TESTRUNNER=$FUCHSIA_DIR/buildtools/linux-x64/testrunner
+
+QEMU_ZBI=/tmp/fuchsia-qemu.zbi
+OUTPUT_FS=/tmp/output.fs
+HOST_ARCHIVE=/tmp/host-archive.tar

--- a/scripts/testing/host-test.sh
+++ b/scripts/testing/host-test.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+set -x trace
+set -o pipefail
+
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. "$CURRENT_DIR"/env.sh
+
+cd $FUCHSIA_DIR
+
+$TESTSHARDER -build-dir out/default -output-file $ALL_TESTS
+jq '.[] | select(.name == "Linux") | .tests' $ALL_TESTS -a > $HOST_TESTS
+
+$TESTRUNNER -C out/default -archive $HOST_ARCHIVE $HOST_TESTS
+
+SUMMARY=`tar -axf $HOST_ARCHIVE summary.json -O`
+
+! echo $SUMMARY | grep FAIL > /dev/null

--- a/scripts/testing/jenkins-fetch-code.sh
+++ b/scripts/testing/jenkins-fetch-code.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+set -x
+set -o pipefail
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. "$CURRENT_DIR"/env.sh
+
+if [ ! -z ${JENKINS_HOME+x} ]; 
+then
+
+	echo "here"
+	cd $FUCHSIA_DIR
+	curl -s "https://fuchsia.googlesource.com/jiri/+/master/scripts/bootstrap_jiri?format=TEXT" | base64 --decode | bash -s $FUCHSIA_DIR
+
+	$JIRI import -name=integration -remote-branch fuchsia-rs \
+		flower https://github.com/fuchsia-rs/integration
+	$JIRI override -path=unused fuchsia https://github.com/fuchsia-rs/fuchsia-rs
+	$JIRI update
+	$JIRI override -delete fuchsia
+	$JIRI run-hooks
+else
+	echo "currently not in jenkins environment."
+fi

--- a/scripts/testing/qemu-test.sh
+++ b/scripts/testing/qemu-test.sh
@@ -11,6 +11,7 @@ CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $FUCHSIA_DIR
 
 cat > $QEMU_TEST_CMDS << EOF
+
 mkdir /tmp/infra-test-output
 waitfor class=block topo=/dev/sys/pci/00:06.0/virtio-block/block timeout=60000
 mount /dev/sys/pci/00:06.0/virtio-block/block /tmp/infra-test-output 

--- a/scripts/testing/qemu-test.sh
+++ b/scripts/testing/qemu-test.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -e
+set -x trace
+set -o pipefail
+
+
+CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+. "$CURRENT_DIR"/env.sh
+
+cd $FUCHSIA_DIR
+
+cat > $QEMU_TEST_CMDS << EOF
+mkdir /tmp/infra-test-output
+waitfor class=block topo=/dev/sys/pci/00:06.0/virtio-block/block timeout=60000
+mount /dev/sys/pci/00:06.0/virtio-block/block /tmp/infra-test-output 
+runtests -o /tmp/infra-test-output -f /boot/infra/tests.lst || echo "1" > /tmp/infra-test-output/result
+echo "0" > /tmp/infra-test-output/result 
+umount /tmp/infra-test-output
+dm poweroff
+EOF
+
+buildtools/linux-x64/testsharder -build-dir out/default -output-file $ALL_TESTS
+jq -r '.[] | select(.name == "QEMU") | .tests | .[] | .location' $ALL_TESTS > $QEMU_TESTS
+
+$ZBI -o $QEMU_ZBI out/default/fuchsia.zbi \
+	-e "infra/runcmds=$QEMU_TEST_CMDS" -e "infra/tests.lst=$QEMU_TESTS"
+
+$MINFS "$OUTPUT_FS"@1G create
+
+$FX run -k -c "zircon.autorun.system=/boot/bin/sh+/boot/infra/runcmds" -m 4096 -z $QEMU_ZBI -- \
+	-drive file=$OUTPUT_FS,format=raw,if=none,id=testdisk -device virtio-blk-pci,drive=testdisk,addr=06.0
+$MINFS $OUTPUT_FS cp :: $QEMU_HOST_RESULTS_DIR
+
+test -f $QEMU_HOST_RESULTS_DIR/result  
+cat $QEMU_HOST_RESULTS_DIR/result | xargs test 0 = 
+! cat $QEMU_HOST_RESULTS_DIR/summary.json | grep FAIL > /dev/null


### PR DESCRIPTION
1. build.sh: build the specific product (core, bringup, etc..)
2. env.sh: provide the common environment variables
3. host-test.sh: for testing in host environment
4. jenkins-fetch-code.sh: for Jenkins fetch the code for testing
5. qemu-test.sh: for testing in qemu environment
